### PR TITLE
pkg/packet/bgp: add mutex to PrefixDefault to avoid data race

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 type MarshallingOption struct {
@@ -1229,23 +1230,36 @@ func LabelString(nlri AddrPrefixInterface) string {
 }
 
 type PrefixDefault struct {
+	mu      sync.Mutex
 	id      uint32
 	localId uint32
 }
 
 func (p *PrefixDefault) PathIdentifier() uint32 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.id
 }
 
 func (p *PrefixDefault) SetPathIdentifier(id uint32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.id = id
 }
 
 func (p *PrefixDefault) PathLocalIdentifier() uint32 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.localId
 }
 
 func (p *PrefixDefault) SetPathLocalIdentifier(id uint32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.localId = id
 }
 


### PR DESCRIPTION
Signed-off-by: Matt Layher <mlayher@fastly.com>

Pull this into the fork to fix the immediate issue.